### PR TITLE
set CMAKE_GENERATOR variable

### DIFF
--- a/pico-env.cmd
+++ b/pico-env.cmd
@@ -3,6 +3,7 @@
 set ProgRoot=%ProgramFiles%
 if not "%ProgramFiles(x86)%" == "" set ProgRoot=%ProgramFiles(x86)%
 set "PATH=%ProgRoot%\Microsoft Visual Studio\Installer;%PATH%"
+set CMAKE_GENERATOR="NMake Makefiles"
 
 for %%i in (sdk examples extras playground) do (
   rem Environment variables in Windows aren't case-sensitive, so we don't need


### PR DESCRIPTION
Set default `CMake Generator` to `NMake Makefiles` so the extra step can be avoided while building and using VS code CMake extension