### PR TITLE
Bump CMake version to avoid rebuild-bug

### DIFF
--- a/x64.json
+++ b/x64.json
@@ -10,9 +10,9 @@
     },
     {
       "name": "CMake",
-      "file": "cmake-3.20.0-windows-x86_64.msi",
+      "file": "cmake-3.20.1-windows-x86_64.msi",
       "exec": "msiexec /i \"$0\" /qn /norestart ADD_CMAKE_TO_PATH=System",
-      "href": "https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-windows-x86_64.msi"
+      "href": "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1-windows-x86_64.msi"
     },
     {
       "name": "Build Tools for Visual Studio 2019",

--- a/x86.json
+++ b/x86.json
@@ -10,9 +10,9 @@
     },
     {
       "name": "CMake",
-      "file": "cmake-3.20.0-windows-i386.msi",
+      "file": "cmake-3.20.1-windows-i386.msi",
       "exec": "msiexec /i \"$0\" /qn /norestart ADD_CMAKE_TO_PATH=System",
-      "href": "https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-windows-i386.msi"
+      "href": "https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1-windows-i386.msi"
     },
     {
       "name": "Build Tools for Visual Studio 2019",


### PR DESCRIPTION
This is because of the [bug](https://gitlab.kitware.com/cmake/cmake/-/issues/21997) explained [here](https://github.com/raspberrypi/pico-sdk/issues/169) and [here](https://github.com/raspberrypi/pico-feedback/issues/111).

This _only_ affected CMake 3.20.0, CMake 3.19.x was fine.