### PR TITLE
Fixed picoprobe and pico-docs download scripts

### DIFF
--- a/pico-docs.ps1
+++ b/pico-docs.ps1
@@ -6,9 +6,9 @@ $ProgressPreference = 'SilentlyContinue'
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
-crawl 'https://www.raspberrypi.org/documentation/pico/getting-started/' |
+crawl 'https://www.raspberrypi.org/documentation/microcontrollers/raspberry-pi-pico.html' |
   Sort-Object -Unique |
-  Where-Object { ([uri]$_).Authority -match '\.raspberrypi.org$' } |
+  Where-Object { ([uri]$_).Authority -match '\.raspberrypi.com$' } |
   ForEach-Object {
     $dir = $null
 

--- a/pico-docs.ps1
+++ b/pico-docs.ps1
@@ -6,7 +6,7 @@ $ProgressPreference = 'SilentlyContinue'
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
-crawl 'https://www.raspberrypi.org/documentation/microcontrollers/raspberry-pi-pico.html' |
+crawl 'https://www.raspberrypi.com/documentation/microcontrollers/raspberry-pi-pico.html' |
   Sort-Object -Unique |
   Where-Object { ([uri]$_).Authority -match '\.raspberrypi.com$' } |
   ForEach-Object {

--- a/pico-setup.cmd
+++ b/pico-setup.cmd
@@ -57,6 +57,9 @@ for %%i in (picoprobe) do (
     set "REPO_URL=%GITHUB_PREFIX%%%i%GITHUB_SUFFIX%"
     echo Cloning !REPO_URL!
     git clone -b %SDK_BRANCH% !REPO_URL! || exit /b 1
+    pushd DEST
+    git submodule update --init
+    popd	
   )
 
   echo Building %%i

--- a/pico-setup.cmd
+++ b/pico-setup.cmd
@@ -57,9 +57,9 @@ for %%i in (picoprobe) do (
     set "REPO_URL=%GITHUB_PREFIX%%%i%GITHUB_SUFFIX%"
     echo Cloning !REPO_URL!
     git clone -b %SDK_BRANCH% !REPO_URL! || exit /b 1
-    pushd DEST
-    git submodule update --init
-    popd	
+    pushd "!DEST!"
+    git submodule update --init || exit /b 1
+    popd
   )
 
   echo Building %%i


### PR DESCRIPTION
The current installer fails to build picoprobe, because the picoprobe repo added sub-modules. The patch added a git submodule update --init to bring in those submodules.

The current installer fails to download the documentation from the raspberrypi website because the layout of the website has changed. The patch updates the download process to reflect those changes.

Note: the current build file fails to build the installer because of problems building openocd. This was not addressed.